### PR TITLE
Feature/t 002 criar missoes mapper dto

### DIFF
--- a/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesController.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesController.java
@@ -5,29 +5,33 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("missoes")
+@RequestMapping("/missoes")
 public class MissoesController {
 
     private MissoesService missoesService;
 
-    @GetMapping("/todasMissoes")
-    public List<MissoesModel> verMissoes(){
+    public MissoesController(MissoesService missoesService) {
+        this.missoesService = missoesService;
+    }
+
+    @GetMapping("/listar")
+    public List<MissoesDTO> verMissoes(){
         return missoesService.verMissoes();
     }
 
-    @GetMapping("/verMissao/{id}")
-    public MissoesModel verMissao(@PathVariable Long id){
+    @GetMapping("/listar/{id}")
+    public MissoesDTO verMissao(@PathVariable Long id){
         return missoesService.verMissao(id);
     }
 
     @PostMapping("/criar")
-    public MissoesModel criarMissao(@RequestBody MissoesModel missao){
+    public MissoesDTO criarMissao(@RequestBody MissoesDTO missao){
         return missoesService.criarMissao(missao);
     }
 
     @PutMapping("/alterar/{id}")
-    public String editarMissao(){
-        return "Missão editada";
+    public MissoesDTO editarMissao(@PathVariable Long id, @RequestBody MissoesDTO missaoDTO){
+        return missoesService.alterarMissao(id, missaoDTO);
     }
 
     @DeleteMapping("/deletar/{id}")

--- a/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesDTO.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesDTO.java
@@ -1,0 +1,20 @@
+package dev.java10x.CadastroDeNinjas.Missoes;
+
+import dev.java10x.CadastroDeNinjas.Ninjas.NinjaModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MissoesDTO {
+
+    private Long id;
+    private String nome;
+    private String dificuldade;
+    private List<NinjaModel> ninjas;
+
+}

--- a/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesMapper.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesMapper.java
@@ -1,0 +1,25 @@
+package dev.java10x.CadastroDeNinjas.Missoes;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MissoesMapper {
+
+    public MissoesModel map(MissoesDTO missoesDTO){
+        MissoesModel missoesModel = new MissoesModel();
+        missoesModel.setId(missoesDTO.getId());
+        missoesModel.setNome(missoesDTO.getNome());
+        missoesModel.setDificuldade(missoesDTO.getDificuldade());
+        missoesModel.setNinjas(missoesDTO.getNinjas());
+        return missoesModel;
+    }
+
+    public MissoesDTO map(MissoesModel missoesModel){
+        MissoesDTO missoesDTO = new MissoesDTO();
+        missoesDTO.setId(missoesModel.getId());
+        missoesDTO.setNome(missoesModel.getNome());
+        missoesDTO.setDificuldade(missoesModel.getDificuldade());
+        missoesDTO.setNinjas(missoesModel.getNinjas());
+        return missoesDTO;
+    }
+}

--- a/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesService.java
+++ b/src/main/java/dev/java10x/CadastroDeNinjas/Missoes/MissoesService.java
@@ -1,32 +1,49 @@
 package dev.java10x.CadastroDeNinjas.Missoes;
 
-import dev.java10x.CadastroDeNinjas.Ninjas.NinjaModel;
-import dev.java10x.CadastroDeNinjas.Ninjas.NinjaRepository;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+@Service
 public class MissoesService {
 
     private MissoesRepository missoesRepository;
+    private MissoesMapper missoesMapper;
 
-
-    public MissoesService(MissoesRepository missoesRepository) {
+    public MissoesService(MissoesRepository missoesRepository, MissoesMapper missoesMapper) {
         this.missoesRepository = missoesRepository;
+        this.missoesMapper = missoesMapper;
     }
 
-    public List<MissoesModel> verMissoes(){
-        return missoesRepository.findAll();
+    public List<MissoesDTO> verMissoes(){
+        List<MissoesModel> missoes = missoesRepository.findAll();
+        return missoes.stream()
+                .map(missoesMapper::map)
+                .collect(Collectors.toList());
     }
 
-    public MissoesModel verMissao(Long id){
+    public MissoesDTO verMissao(Long id){
         Optional<MissoesModel> missao = missoesRepository.findById(id);
-        return missao.orElse(null);
+        return missao.map(missoesMapper::map).orElse(null);
     }
 
-    public MissoesModel criarMissao(MissoesModel missao){
-        return missoesRepository.save(missao);
+    public MissoesDTO criarMissao(MissoesDTO missaoDTO){
+        MissoesModel missao = missoesMapper.map(missaoDTO);
+        missao = missoesRepository.save(missao);
+        return missoesMapper.map(missao);
+    }
+
+    public MissoesDTO alterarMissao(Long id, MissoesDTO missaoDTO){
+        Optional<MissoesModel> missaoExistente = missoesRepository.findById(id);
+        if(missaoExistente.isPresent()){
+            MissoesModel missao = missoesMapper.map(missaoDTO);
+            missao.setId(id);
+            MissoesModel missaoAlterada = missoesRepository.save(missao);
+            return missoesMapper.map(missaoAlterada);
+        }
+        return null;
     }
 
     public void deletarMissao(Long id){


### PR DESCRIPTION
Proposed Changes by the PR

Implementation of MissoesMapper for conversion between MissoesModel and MissoesDTO.
Creation of MissoesDTO containing the necessary fields for external communication.
Refactoring of MissoesService to use MissoesDTO, eliminating direct exposure of MissoesModel.
Adjustments to MissoseController to work with MissoesDTO, ensuring a more cohesive and decoupled structure.

These changes aim to improve code organization and separation of responsibilities, facilitating maintenance and future expansion of the application.